### PR TITLE
Fix bugs with convolution modes in dnn_params.h when using MIOpen

### DIFF
--- a/core/include/dnn_param.h
+++ b/core/include/dnn_param.h
@@ -152,7 +152,7 @@ inline void SetupConvParam(const std::string &var, const std::string &val,
         conv_param->mode_ = miopenTranspose;
 #endif
       else
-        LOG(FATAL) << "Invalid conv mode" << std::endl;
+        LOG(FATAL) << "Invalid conv mode: " << val << std::endl;
     } else if (!var.compare("num_output")) {
       conv_param->output_num_ = atoi(val.c_str());
     } else if (!var.compare("kernel_size")) {

--- a/core/include/dnn_param.h
+++ b/core/include/dnn_param.h
@@ -140,9 +140,12 @@ inline void SetupConvParam(const std::string &var, const std::string &val,
 #ifdef AMD_MIOPEN
         conv_param->mode_ = miopenConvolution;
 #endif
-#ifdef NVIDIA_CUDNN
       else if (!val.compare("cross_correlation"))
+#ifdef NVIDIA_CUDNN
         conv_param->mode_ = CUDNN_CROSS_CORRELATION;
+#endif
+#ifdef AMD_MIOPEN
+        conv_param->mode_ = miopenConvolution;
 #endif
 #ifdef MIOPEN
       else if (!val.compare("transpose"))

--- a/core/include/dnn_param.h
+++ b/core/include/dnn_param.h
@@ -147,7 +147,7 @@ inline void SetupConvParam(const std::string &var, const std::string &val,
 #ifdef AMD_MIOPEN
         conv_param->mode_ = miopenConvolution;
 #endif
-#ifdef MIOPEN
+#ifdef AMD_MIOPEN
       else if (!val.compare("transpose"))
         conv_param->mode_ = miopenTranspose;
 #endif


### PR DESCRIPTION
These commits resolve issue #14 and also address an additional issue in dnn_params.h with the transpose mode.  Finally, these commits also augment the error print when the convolution mode can't be found.