### PR TITLE
Fix size conversion between different functions.

### DIFF
--- a/core/include/data_manager.h
+++ b/core/include/data_manager.h
@@ -36,10 +36,10 @@ template <typename T>
 class Data {
  private:
   PseudoNumGenerator *png_;
-  int size_;
+  size_t size_;
   T *gpu_ptr_;
  public:
-  Data(int size)
+  Data(size_t size)
   : size_(size) {
     LOG(INFO) << "Create Data chunk of size " << size_;
 #ifdef NVIDIA_CUDNN
@@ -94,7 +94,7 @@ class DataManager {
     gpu_data_pool_.clear();
   }
 
-  int CreateData(int size) {
+  int CreateData(size_t size) {
     int gen_chunk_id = num_data_chunks_;
     num_data_chunks_++;
     gpu_data_pool_.emplace(gen_chunk_id, std::make_shared<Data<T>>(size));


### PR DESCRIPTION
DNNMark uses a size_t for calculating the workspace size, but passes it down to functions that use it as an int.  This causes the workspace size to be inverted to very large negative numbers when the batch sizes are large.  Currently this only affects fwd_lrn and bwd_lrn when I make the batch size 256+, but it could
affect any of the others given large enough batch sizes.