### PR TITLE
Fixes initialization for top_diffs in fc layer

### DIFF
--- a/core/include/layers/fc_layer.h
+++ b/core/include/layers/fc_layer.h
@@ -180,10 +180,9 @@ class FullyConnectedLayer : public Layer<T> {
   void BackwardPropagation() {
     if (p_dnnmark_->getRunMode() == STANDALONE ||
         !previous_layer_name_.compare("null")) {
-      // Fill the top and top diff data
+      // Fill the top diff data
       for (int i = 0; i < num_tops_; i++) {
-        tops_[i]->Filler();
-        tops_[i]->Filler();
+        top_diffs_[i]->Filler();
       }
       // Fill the bottom data
       for (int i = 0; i < num_bottoms_; i++) {


### PR DESCRIPTION
Fill the top diff data instead of tops in initialization code for fc layer BackwardPropogation.